### PR TITLE
docs: clarify MSX BASIC limitation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ PRINT USR1("&position#0")
 1.0
 ```
 
-If the string length is greater than 255 chars, then only the first 255 chars will be returned (this is limitation of MSX BASIC).
+If the string length is greater than 255 chars, then only the first 255 chars will be returned (this is a limitation of MSX BASIC).
 
 Errors:
 * Returns `Type mismatch` if `Q$` is not a string.


### PR DESCRIPTION
## Summary
- clarify phrasing about MSX BASIC string-length limitation in README

## Testing
- `make -B test` *(fails: `sjasmplus` not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689781c08ffc832f8daa37eb11118b86